### PR TITLE
Sparkpost clean up

### DIFF
--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/Client.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/Client.java
@@ -1,10 +1,10 @@
 
 package com.sparkpost;
 
+import com.sparkpost.model.AddressAttributes;
+
 import java.util.List;
 import java.util.Map;
-
-import com.sparkpost.model.AddressAttributes;
 
 /**
  * The Client class stores everything specific to the SparkPost client:<BR>
@@ -77,7 +77,7 @@ public class Client {
         this.fromEmail = fromEmail;
     }
 
-    public void sendMessage(String termplateId, List<AddressAttributes> recipients, Map<String, String> args) {
+    public void sendMessage(String templateId, List<AddressAttributes> recipients, Map<String, String> args) {
 
     }
 

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/model/Base.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/model/Base.java
@@ -10,6 +10,9 @@ import com.google.gson.GsonBuilder;
  */
 public class Base {
 
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+    private static final GsonBuilder GSON_BUILDER = new GsonBuilder().setDateFormat(DATE_TIME_FORMAT);
+
     /**
      * Generate JSON for this request
      * 
@@ -25,12 +28,11 @@ public class Base {
      * @return json of object
      */
     public String toJson(boolean prettyPrint) {
-        GsonBuilder gsonBuilder = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss");
         Gson gson;
         if (prettyPrint) {
-            gson = gsonBuilder.setPrettyPrinting().create();
+            gson = GSON_BUILDER.setPrettyPrinting().create();
         } else {
-            gson = gsonBuilder.create();
+            gson = GSON_BUILDER.create();
         }
 
         return gson.toJson(this);

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/model/TemplateSubstitutionData.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/model/TemplateSubstitutionData.java
@@ -1,14 +1,13 @@
 
 package com.sparkpost.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.google.gson.annotations.SerializedName;
 import com.yepher.jsondoc.annotations.Description;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * DTO for storing substitution data (list of key=value).
@@ -17,7 +16,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public class TemplateSubstitutionData extends Base {
 
-    @Description(value = "Data the will be substituted into the template", sample = {"Dictionary of ssubstitution data"})
+    @Description(value = "Data the will be substituted into the template", sample = {"Dictionary of substitution data"})
     @SerializedName("substitution_data")
     private Map<String, String> substitutionData = new HashMap<String, String>();
 

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/model/responses/Response.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/model/responses/Response.java
@@ -18,6 +18,8 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public class Response extends Base {
 
+    private static final Gson GSON = new Gson();
+
     @Description(value = "The URI of the request", sample = {""})
     private String request = null;
 
@@ -38,15 +40,13 @@ public class Response extends Base {
     private String responseBody = null;
 
     public static <T extends Response> T decode(Response response, Type typeOfT) {
-        Gson gson = new Gson();
-
         T newResponse = null;
 
         // Make sure this is a JSON response before we try and decode with GSON
         if (response.getContentType() != null && response.getContentType().toLowerCase().startsWith("application/json")) {
-            newResponse = gson.fromJson(response.getResponseBody(), typeOfT);
+            newResponse = GSON.fromJson(response.getResponseBody(), typeOfT);
         } else {
-            newResponse = gson.fromJson("{}", typeOfT);
+            newResponse = GSON.fromJson("{}", typeOfT);
         }
 
         if (newResponse != null) {

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/resources/Endpoint.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/resources/Endpoint.java
@@ -21,6 +21,20 @@ public class Endpoint {
         this.uriBuilder.addParameter(name, value);
     }
 
+    public Endpoint addCommonParams(String from, String to, String domains, String campaigns, String templates, String metrics,
+                                    String timezone, String limit, String orderBy) {
+        addParam("from", from);
+        addParam("to", to);
+        addParam("domains", domains);
+        addParam("campaigns", campaigns);
+        addParam("templates", templates);
+        addParam("metrics", metrics);
+        addParam("timezone", timezone);
+        addParam("limit", limit);
+        addParam("order_by", orderBy);
+        return this;
+    }
+
     public Endpoint addParam(String name, String val) {
         if (val != null) {
             addString(name, val);

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/resources/ResourceMetrics.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/resources/ResourceMetrics.java
@@ -30,13 +30,7 @@ public class ResourceMetrics {
             String timezone) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -55,15 +49,7 @@ public class ResourceMetrics {
             String order_by) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/domain");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
-        ep.addParam("limit", limit);
-        ep.addParam("order_by", order_by);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, order_by);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -83,15 +69,7 @@ public class ResourceMetrics {
             String order_by) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/campaign");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
-        ep.addParam("limit", limit);
-        ep.addParam("order_by", order_by);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, order_by);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -110,15 +88,8 @@ public class ResourceMetrics {
             String order_by) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/template");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
-        ep.addParam("limit", limit);
-        ep.addParam("order_by", order_by);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, order_by);
+
 
         Response response = conn.get(ep.toString());
         return response;
@@ -137,15 +108,8 @@ public class ResourceMetrics {
             String order_by) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/watched-domain");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
-        ep.addParam("limit", limit);
-        ep.addParam("order_by", order_by);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, order_by);
+
 
         Response response = conn.get(ep.toString());
         return response;
@@ -163,14 +127,9 @@ public class ResourceMetrics {
             String timezone) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/time-series");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
+
         ep.addParam("precision", precision);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -188,14 +147,9 @@ public class ResourceMetrics {
             String limit) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/bounce-reason");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
+
         ep.addParam("limit", limit);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -213,14 +167,9 @@ public class ResourceMetrics {
             String limit) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/bounce-reason/domain");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
+
         ep.addParam("limit", limit);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -238,14 +187,9 @@ public class ResourceMetrics {
             String limit) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/bounce-classification");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("metrics", metrics);
-        ep.addParam("timezone", timezone);
+
         ep.addParam("limit", limit);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -262,13 +206,9 @@ public class ResourceMetrics {
             String limit) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/rejection-reason");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("timezone", timezone);
+
         ep.addParam("limit", limit);
+        ep.addCommonParams(from, to, domains, campaigns, templates, null, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -285,13 +225,9 @@ public class ResourceMetrics {
             String limit) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/rejection-reason/domain");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("timezone", timezone);
+
         ep.addParam("limit", limit);
+        ep.addCommonParams(from, to, domains, campaigns, templates, null, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -308,13 +244,9 @@ public class ResourceMetrics {
             String limit) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/delay-reason");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("timezone", timezone);
+
         ep.addParam("limit", limit);
+        ep.addCommonParams(from, to, domains, campaigns, templates, null, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -331,13 +263,9 @@ public class ResourceMetrics {
             String limit) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/delay-reason/domain");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("timezone", timezone);
+
         ep.addParam("limit", limit);
+        ep.addCommonParams(from, to, domains, campaigns, templates, null, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -354,13 +282,9 @@ public class ResourceMetrics {
             String limit) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/link-name");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("timezone", timezone);
-        ep.addParam("metrics", metrics);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
+
         ep.addParam("limit", limit);
+        ep.addCommonParams(from, to, null, campaigns, templates, metrics, timezone, null, null);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -376,12 +300,8 @@ public class ResourceMetrics {
             String timezone) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/attempt");
-        ep.addParam("from", from);
-        ep.addParam("to", to);
-        ep.addParam("domains", domains);
-        ep.addParam("campaigns", campaigns);
-        ep.addParam("templates", templates);
-        ep.addParam("timezone", timezone);
+        ep.addCommonParams(from, to, domains, campaigns, templates, null, timezone, null, null);
+
         Response response = conn.get(ep.toString());
         return response;
     }

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/resources/ResourceMetrics.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/resources/ResourceMetrics.java
@@ -46,10 +46,10 @@ public class ResourceMetrics {
             String metrics,
             String timezone,
             String limit,
-            String order_by) throws SparkPostException {
+            String orderBy) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/domain");
-        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, order_by);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, orderBy);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -66,10 +66,10 @@ public class ResourceMetrics {
             String metrics,
             String timezone,
             String limit,
-            String order_by) throws SparkPostException {
+            String orderBy) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/campaign");
-        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, order_by);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, orderBy);
 
         Response response = conn.get(ep.toString());
         return response;
@@ -85,10 +85,10 @@ public class ResourceMetrics {
             String metrics,
             String timezone,
             String limit,
-            String order_by) throws SparkPostException {
+            String orderBy) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/template");
-        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, order_by);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, orderBy);
 
 
         Response response = conn.get(ep.toString());
@@ -105,10 +105,10 @@ public class ResourceMetrics {
             String metrics,
             String timezone,
             String limit,
-            String order_by) throws SparkPostException {
+            String orderBy) throws SparkPostException {
 
         Endpoint ep = new Endpoint("metrics/deliverability/watched-domain");
-        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, order_by);
+        ep.addCommonParams(from, to, domains, campaigns, templates, metrics, timezone, limit, orderBy);
 
 
         Response response = conn.get(ep.toString());

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/resources/ResourceRecipientLists.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/resources/ResourceRecipientLists.java
@@ -18,7 +18,7 @@ import com.sparkpost.transport.RestConnection;
  */
 public class ResourceRecipientLists {
 
-    static public Response create(RestConnection conn, Integer maxNumberOfRecipientErrors, RecipientList recipientList) throws SparkPostException {
+    public static Response create(RestConnection conn, Integer maxNumberOfRecipientErrors, RecipientList recipientList) throws SparkPostException {
         String json = recipientList.toJson();
         Endpoint ep = new Endpoint("recipient-lists");
         ep.addParam("num_rcpt_errors", maxNumberOfRecipientErrors);
@@ -26,19 +26,19 @@ public class ResourceRecipientLists {
         return response;
     }
 
-    static public Response retrieve(RestConnection conn, String recipientListId, Boolean showRecipients) throws SparkPostException {
+    public static Response retrieve(RestConnection conn, String recipientListId, Boolean showRecipients) throws SparkPostException {
         Endpoint ep = new Endpoint("recipient-lists/" + recipientListId);
         ep.addParam("show_recipients", showRecipients);
         Response response = conn.get(ep.toString());
         return response;
     }
 
-    static public Response listAll(RestConnection conn) throws SparkPostException {
+    public static Response listAll(RestConnection conn) throws SparkPostException {
         Response response = conn.get("recipient-lists");
         return response;
     }
 
-    static public Response delete(RestConnection conn, String recipientListId) throws SparkPostException {
+    public static Response delete(RestConnection conn, String recipientListId) throws SparkPostException {
         String path = "recipient-lists/" + recipientListId;
         Response response = conn.delete(path);
         return response;

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
@@ -183,7 +183,7 @@ public class RestConnection {
         }
         // Send data. At this point connection to server may not be established,
         // but writing data to it will trigger the connection.
-        try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream());) {
+        try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
 
             wr.writeBytes(data);
             wr.flush();
@@ -226,7 +226,7 @@ public class RestConnection {
         }
 
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), DEFAULT_CHARSET));) {
+        try (BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), DEFAULT_CHARSET))) {
             // Buffer the result into a string:
             String line;
             while ((line = rd.readLine()) != null) {

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
@@ -33,6 +33,9 @@ public class RestConnection {
     // TODO: set this up to be set by build machine.
     private static final String VERSION = "0.0.1-SNAPSHOT";
 
+    private static final Base64 BASE64 = new Base64();
+    private static final String DEFAULT_CHARSET = "UTF-8";
+
     /**
      * Default endpoint to use for connections :
      * https://api.sparkpost.com/api/v1/
@@ -113,8 +116,7 @@ public class RestConnection {
             if (StringUtils.isNotEmpty(this.client.getAuthKey())) {
                 conn.setRequestProperty("Authorization", this.client.getAuthKey());
             } else if (StringUtils.isNotEmpty(this.client.getUsername()) && StringUtils.isNotEmpty(this.client.getPassword())) {
-                Base64 b = new Base64();
-                String encoding = b.encodeAsString((this.client.getUsername() + ":" + this.client.getPassword()).getBytes("UTF-8"));
+                String encoding = BASE64.encodeAsString((this.client.getUsername() + ":" + this.client.getPassword()).getBytes(DEFAULT_CHARSET));
                 conn.setRequestProperty("Authorization", "Basic " + encoding);
             }
 
@@ -167,7 +169,7 @@ public class RestConnection {
     private void sendData(HttpURLConnection conn, String data) throws SparkPostException {
         String lenStr;
         try {
-            lenStr = Integer.toString(data.getBytes("UTF-8").length);
+            lenStr = Integer.toString(data.getBytes(DEFAULT_CHARSET).length);
         } catch (UnsupportedEncodingException e) {
             // This should never happen. UTF-8 should always be available but we
             // have to catch it so pass it on if it fails.
@@ -224,7 +226,7 @@ public class RestConnection {
         }
 
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));) {
+        try (BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), DEFAULT_CHARSET));) {
             // Buffer the result into a string:
             String line;
             while ((line = rd.readLine()) != null) {


### PR DESCRIPTION
Small clean up.

- Typos and trailing colons.
- Cut down on duplicate code.
- Updated a handful variables to match standard Java naming conventions.
- Extracted a couple of objects that can be static final to stop extra creation when we don't need to.