### PR TITLE
Issue with sending non ANCII chars. They was encoded wrongly.

### DIFF
--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
@@ -184,8 +184,7 @@ public class RestConnection {
         // Send data. At this point connection to server may not be established,
         // but writing data to it will trigger the connection.
         try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
-
-            wr.writeBytes(data);
+            wr.write(data.getBytes(DEFAULT_CHARSET));
             wr.flush();
         } catch (IOException ex) {
             throw new SparkPostException("Error sending request data:" + ex.toString());


### PR DESCRIPTION
"носок" -> "=>A>:".
Issue of rest client outstream "posteroutputstream"
Solved by getting string as byte[] with proper encoding
After fix need new version release