### PR TITLE
Fixing issue #24 `Substitution data as string`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 Use this library in Java applications to easily access the SparkPost Email API in your application.
 
+## Version Compatibility Note
+
+### Version 0.12 -> 0.13
+
+Although we try to maintain library backward compatibility this migration may require some minor changes to your code. Substitution data was changed from `Map<String, String>` to `Map<String, Object>`. Most client code will just need to change their map to this new signature.
+
 ## Getting Started
 
 The SparkPost Java Library is available in this [Maven Repository](http://maven.apache.org/download.cgi):
@@ -17,7 +23,7 @@ The SparkPost Java Library is available in this [Maven Repository](http://maven.
 <dependency>
 	<groupId>com.sparkpost</groupId>
 	<artifactId>sparkpost-lib</artifactId>
-	<version>0.12</version>
+	<version>0.13</version>
 </dependency>
 ```
 

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.sparkpost</groupId>
 		<artifactId>sparkpost</artifactId>
-		<version>0.12</version>
+		<version>0.13</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>apps</artifactId>

--- a/apps/sparkpost-documentor-app/pom.xml
+++ b/apps/sparkpost-documentor-app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.sparkpost</groupId>
 		<artifactId>apps</artifactId>
-		<version>0.12</version>
+		<version>0.13</version>
 	</parent>
 	<artifactId>sparkpost-documentor-app</artifactId>
 	<name>Generates Markdown of Protocol</name>

--- a/apps/sparkpost-javamail-app/pom.xml
+++ b/apps/sparkpost-javamail-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sparkpost</groupId>
 		<artifactId>apps</artifactId>
-		<version>0.12</version>
+		<version>0.13</version>
 	</parent>
 	<groupId>com.sparkpost.sample</groupId>
 	<artifactId>sparkpost-javamail-app</artifactId>

--- a/apps/sparkpost-javamail-app/src/main/java/com/sparkpost/sample/App.java
+++ b/apps/sparkpost-javamail-app/src/main/java/com/sparkpost/sample/App.java
@@ -81,7 +81,7 @@ public class App extends SparkPostBaseApp {
 		transmission.setReturnPath(from);
 
 		// Populate Substitution Data
-		Map<String, String> substitutionData = new HashMap<String, String>();
+		Map<String, Object> substitutionData = new HashMap<String, Object>();
 		substitutionData.put("from", from);
 		
 		// SparkPost will set fields in HTML and/or Plain parts with the value here

--- a/apps/sparkpost-samples-app/pom.xml
+++ b/apps/sparkpost-samples-app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.sparkpost</groupId>
 		<artifactId>apps</artifactId>
-		<version>0.12</version>
+		<version>0.13</version>
 	</parent>
 	<artifactId>sparkpost-samples-app</artifactId>
 	<name>Example use SparkPost library</name>

--- a/apps/sparkpost-samples-app/samples/sample_sp_substitution_email.eml
+++ b/apps/sparkpost-samples-app/samples/sample_sp_substitution_email.eml
@@ -1,0 +1,54 @@
+MIME-Version: 1.0
+Subject: {{subject}}
+To: {{address.email}}
+From: {{from}}
+Content-Type: multipart/alternative; boundary=001a113ed0b2fce06c052ecfc06d
+
+--001a113ed0b2fce06c052ecfc06d
+Content-Type: text/plain; charset=UTF-8
+
+Sample Email with Array Content
+
+Name,\tValue
+{{each row_array}}
+    {{loop_var.row}},\t {{loop_var.value}}
+{{end}}
+
+
+
+End of array data
+
+--001a113ed0b2fce06c052ecfc06d
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr">
+	<div class=3D"gmail_signature">
+		<div dir=3D"ltr">
+			<div>
+				<div>
+					<h1 id=3D"toc_0" style=3D"margin-right:0px;margin-bottom:10px;margin-left:0px;padding:0px;font-size:28px;color:rgb(0,0,0);font-family:Helvetica,arial,sans-serif;margin-top:0px!important">Sample Email with Array Content</h1>
+					<table style=3D"margin:15px 0px;padding:0px;border-collapse:collapse;color:rgb(0,0,0);font-family:Helvetica,arial,sans-serif;font-size:14px">
+						<thead>
+							<tr style=3D"border-top-width:1px;border-top-style:solid;border-top-color:rgb(204,204,204);margin:0px;padding:0px">
+								<th style=3D"border:1px solid rgb(204,204,204);margin:0px;padding:6px 13px">Name</th>
+								<th style=3D"border:1px solid rgb(204,204,204);margin:0px;padding:6px 13px;text-align:center">Value</th>
+							</tr>
+						</thead>
+						<tbody>
+                            {{each row_array}}
+							<tr style=3D"border-top-width:1px;border-top-style:solid;border-top-color:rgb(204,204,204);margin:0px;padding:0px">
+								<td style=3D"border:1px solid rgb(204,204,204);padding:6px 13px">{{loop_var.row}}</td>
+								<td style=3D"border:1px solid rgb(204,204,204);padding:6px 13px;text-align:center">{{loop_var.value}}</td>
+							</tr>
+                            {{end}}
+						</tbody>
+					</table>
+					<p style=3D"margin-top:15px;margin-right:0px;margin-left:0px;color:rgb(0,0,0);font-family:Helvetica,arial,sans-serif;font-size:14px;margin-bottom:0px!important">End of array data</p>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+--001a113ed0b2fce06c052ecfc06d--

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithSubstitutionSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithSubstitutionSample.java
@@ -23,7 +23,7 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailWithSubstitutionSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = Logger.getLogger(SendEmailWithSubstitutionSample.class);
 
     private Client client;
 

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithSubstitutionSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithSubstitutionSample.java
@@ -21,7 +21,7 @@ import com.sparkpost.resources.ResourceTransmissions;
 import com.sparkpost.sdk.samples.helpers.SparkPostBaseApp;
 import com.sparkpost.transport.RestConnection;
 
-public class SendEmailSample extends SparkPostBaseApp {
+public class SendEmailWithSubstitutionSample extends SparkPostBaseApp {
 
     static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
 
@@ -30,7 +30,7 @@ public class SendEmailSample extends SparkPostBaseApp {
     public static void main(String[] args) throws SparkPostException, IOException {
         Logger.getRootLogger().setLevel(Level.DEBUG);
 
-        SendEmailSample sample = new SendEmailSample();
+        SendEmailWithSubstitutionSample sample = new SendEmailWithSubstitutionSample();
         sample.runApp();
     }
 
@@ -38,7 +38,7 @@ public class SendEmailSample extends SparkPostBaseApp {
         this.client = this.newConfiguredClient();
 
         // Loads an email to send from the file system
-        String template = getTemplate("sample_sp_email.eml");
+        String template = getTemplate("sample_sp_substitution_email.eml");
         String fromAddress = getFromAddress();
         String[] recipients = getTestRecipients();
 
@@ -51,11 +51,36 @@ public class SendEmailSample extends SparkPostBaseApp {
 
         // Populate Recipients
         List<RecipientAttributes> recipientArray = new ArrayList<RecipientAttributes>();
+
         for (String recipient : recipients) {
             RecipientAttributes recipientAttribs = new RecipientAttributes();
             recipientAttribs.setAddress(new AddressAttributes(recipient));
             recipientArray.add(recipientAttribs);
+
+            Map<String, Object> substitution = new HashMap<String, Object>();
+            recipientAttribs.setSubstitutionData(substitution);
+            substitution.put("my_string", "This is a string value");
+
+            // Demonstrate dynamic subject per recipient. The subject contains "{{subject}}"
+            substitution.put("subject", "A dynamic subject for " + "\"" + recipient + "\"");
+
+            /*
+             * Demonstrate array of substitution data that is used in plain and HTML parts
+             * Email body will contain:
+             * {{each row_array}}
+             * {{loop_var.row}},\t {{loop_var.value}}
+             * {{end}}
+             */
+            List<Map<String, String>> myArray = new ArrayList<Map<String, String>>();
+            for (int i = 0; i < 10; i++) {
+                Map<String, String> myMap = new HashMap<String, String>();
+                myMap.put("row", "row " + (i + 1));
+                myMap.put("value", "Value " + (i + 1));
+                myArray.add(myMap);
+            }
+            substitution.put("row_array", myArray);
         }
+
         transmission.setRecipientArray(recipientArray);
 
         transmission.setReturnPath(from);

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.sparkpost</groupId>
 		<artifactId>sparkpost</artifactId>
-		<version>0.12</version>
+		<version>0.13</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>libs</artifactId>

--- a/libs/sparkpost-lib/pom.xml
+++ b/libs/sparkpost-lib/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.sparkpost</groupId>
 		<artifactId>libs</artifactId>
-		<version>0.12</version>
+		<version>0.13</version>
 	</parent>
 	<!-- <version>0.10</version> -->
 	<artifactId>sparkpost-lib</artifactId>

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/model/OptionsAttributes.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/model/OptionsAttributes.java
@@ -60,4 +60,12 @@ public class OptionsAttributes extends Base {
     @Description(value = "Unlike most other options, this flag is omitted on a GET transmission response unless the flag's value is true.", sample = {""})
     @SerializedName("skip_suppression")
     private Boolean skipSuppression;
+
+    /**
+     * Whether or not to perform CSS inlining in HTML content
+     * Defaults to false
+     */
+    @Description(value = "Whether or not to perform CSS inlining in HTML content.", sample = {""})
+    @SerializedName("inline_css")
+    private Boolean inlineCss;
 }

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/model/RecipientAttributes.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/model/RecipientAttributes.java
@@ -62,6 +62,6 @@ public class RecipientAttributes extends Base {
      */
     @Description(value = "Key/value pairs associated with a recipient that are provided to the substitution engine", sample = {""})
     @SerializedName("substitution_data")
-    private Map<String, String> substitutionData = null;
+    private Map<String, Object> substitutionData = null;
 
 }

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/model/TemplateSubstitutionData.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/model/TemplateSubstitutionData.java
@@ -1,13 +1,14 @@
 
 package com.sparkpost.model;
 
-import com.google.gson.annotations.SerializedName;
-import com.yepher.jsondoc.annotations.Description;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+import com.yepher.jsondoc.annotations.Description;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * DTO for storing substitution data (list of key=value).
@@ -18,6 +19,6 @@ public class TemplateSubstitutionData extends Base {
 
     @Description(value = "Data the will be substituted into the template", sample = {"Dictionary of substitution data"})
     @SerializedName("substitution_data")
-    private Map<String, String> substitutionData = new HashMap<String, String>();
+    private Map<String, Object> substitutionData = new HashMap<String, Object>();
 
 }

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/model/TransmissionBase.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/model/TransmissionBase.java
@@ -84,7 +84,7 @@ public class TransmissionBase extends Base {
             value = "Key/value pairs that are provided to the substitution engine. Recipient substitution data takes precedence over transmission substitution data. Unlike metadata, substitution data is not included in Webhook events.",
             sample = {""})
     @SerializedName("substitution_data")
-    private Map<String, String> substitutionData = null;
+    private Map<String, Object> substitutionData = null;
 
     /**
      * Email to use for envelope FROM ( Note: SparkPost Elite only )

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientAttributesTest.java
@@ -36,7 +36,8 @@ public class RecipientAttributesTest {
             + "        \"place\": \"Bedrock\"\n"
             + "      },\n"
             + "      \"substitution_data\": {\n"
-            + "        \"customer_type\": \"Platinum\"\n"
+            + "        \"customer_type\": \"Platinum\",\n"
+            + "        \"array_data\": [ \"object1\", \"object2\", \"object3\" ]\n"
             + "      }\n"
             + "    }";
 
@@ -81,8 +82,15 @@ public class RecipientAttributesTest {
         Map<String, String> metadata = recipientAttributes.getMetadata();
         MatcherAssert.assertThat(metadata, Matchers.hasEntry("place", "Bedrock"));
 
-        Map<String, String> substitutionData = recipientAttributes.getSubstitutionData();
-        MatcherAssert.assertThat(substitutionData, Matchers.hasEntry("customer_type", "Platinum"));
+        String result = (String) recipientAttributes.getSubstitutionData().get("customer_type");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result, "Platinum");
+
+        @SuppressWarnings("unchecked")
+        List<String> arrayData = (List<String>) recipientAttributes.getSubstitutionData().get("array_data");
+        Assert.assertNotNull(arrayData);
+        Assert.assertEquals(arrayData.size(), 3);
+
     }
 
     /**
@@ -114,8 +122,11 @@ public class RecipientAttributesTest {
         Map<String, String> metadata = recipientAttributes2.getMetadata();
         MatcherAssert.assertThat(metadata, Matchers.hasEntry("place", "Bedrock"));
 
-        Map<String, String> substitutionData = recipientAttributes.getSubstitutionData();
-        MatcherAssert.assertThat(substitutionData, Matchers.hasEntry("customer_type", "Platinum"));
+        Map<String, Object> substitutionData = recipientAttributes.getSubstitutionData();
+        String result = (String) substitutionData.get("customer_type");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result, "Platinum");
+
     }
 
 }

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TransmissionWithRecipientArrayTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TransmissionWithRecipientArrayTest.java
@@ -105,7 +105,7 @@ public class TransmissionWithRecipientArrayTest {
         Map<String, String> metadata = transmissionWithRecipientArray.getMetadata();
         Assert.assertNotNull(metadata);
 
-        Map<String, String> substitutionData = transmissionWithRecipientArray.getSubstitutionData();
+        Map<String, Object> substitutionData = transmissionWithRecipientArray.getSubstitutionData();
         Assert.assertNotNull(substitutionData);
 
         List<RecipientAttributes> recipientArray = transmissionWithRecipientArray.getRecipientArray();

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sparkpost</groupId>
 	<artifactId>sparkpost</artifactId>
-	<version>0.12</version>
+	<version>0.13</version>
 	<packaging>pom</packaging>
 	<name>*** SparkPost Java Code ***</name>
 	<description>SparkPost client library for Java https://www.sparkpost.com/</description>
@@ -258,7 +258,7 @@
 			<dependency>
 				<groupId>com.sparkpost</groupId>
 				<artifactId>sparkpost-lib</artifactId>
-				<version>0.12</version>
+				<version>0.13</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
Fixing issue #24 - Substitution data as string

Changes:

* Changes pom version from 0.12 to 0.13
* Adds css_inline
* Adds ability to do more complex content substitution
* Adds addition unit test logic for content substitution
* Adds sample app that demonstrates simple field substitution and array substitution  