### PR TITLE
Adding proxy option

### DIFF
--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/Client.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/Client.java
@@ -145,10 +145,10 @@ public class Client {
         TransmissionWithRecipientArray transmission = new TransmissionWithRecipientArray();
 
         List<RecipientAttributes> recipientArray = new ArrayList<RecipientAttributes>();
-        for (String recpient : recipients) {
+        for (String recipient : recipients) {
 
             RecipientAttributes recipientAttribs = new RecipientAttributes();
-            recipientAttribs.setAddress(new AddressAttributes(recpient));
+            recipientAttribs.setAddress(new AddressAttributes(recipient));
             recipientArray.add(recipientAttribs);
         }
         transmission.setRecipientArray(recipientArray);

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/Client.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/Client.java
@@ -1,6 +1,8 @@
 
 package com.sparkpost;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -105,6 +107,16 @@ public class Client {
 
     public int getHttpConnectTimeout() {
         return this.httpConnectTimeout;
+    }
+
+    private Proxy proxy = null;
+
+    public void setProxy(String hostname, int port) {
+        proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(hostname, port));
+    }
+
+    public Proxy getProxy() {
+        return this.proxy;
     }
 
     /**

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
@@ -115,7 +115,12 @@ public class RestConnection implements IRestConnection {
             // Retrieve the URLConnection object (but doesn't actually connect):
             // (HttpUrlConnection doesn't connect to the server until we've
             // got one of its streams)
-            conn = (HttpURLConnection) url.openConnection();
+            if(this.client.getProxy() != null) {
+                System.out.println("Using proxy here!");
+                conn = (HttpURLConnection) url.openConnection(this.client.getProxy());
+            } else {
+                conn = (HttpURLConnection) url.openConnection();
+            }
 
             conn.setConnectTimeout(this.client.getHttpConnectTimeout());
             conn.setReadTimeout(this.client.getHttpReadTimeout());

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
@@ -112,11 +112,15 @@ public class RestConnection implements IRestConnection {
             URL url;
             url = new URL(this.baseUrl + path);
 
-            // Retrieve the URLConnection object (but doesn't actually connect):
-            // (HttpUrlConnection doesn't connect to the server until we've
-            // got one of its streams)
+            /*
+
+             Retrieve the URLConnection object (but doesn't actually connect):
+             (HttpUrlConnection doesn't connect to the server until we've
+             got one of its streams)
+             Enable Client to set up proxy if need be
+              */
+
             if(this.client.getProxy() != null) {
-                System.out.println("Using proxy here!");
                 conn = (HttpURLConnection) url.openConnection(this.client.getProxy());
             } else {
                 conn = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
**TL;DR**: At Booking.com we use proxy servers for outgoing traffic, so we've added an optional proxy parameter to _Client_ and added proxy support to _RestConnection_.

We haven't found any other way to use your Java library for sending emails from behind proxy servers other than to create this patch. To the best of our knowledge it is backward compatible (will work without proxy as previously unless explicitly specified otherwise).