### PR TITLE
Issue #75

### DIFF
--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
@@ -10,7 +10,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
-
+import lombok.Getter;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -43,6 +43,7 @@ public class RestConnection implements IRestConnection {
 
     private final Client client;
 
+    @Getter
     private final String baseUrl;
 
     /**
@@ -90,8 +91,8 @@ public class RestConnection implements IRestConnection {
             this.baseUrl = baseUrl;
         }
 
-        if (baseUrl.endsWith("/")) {
-            throw new IllegalStateException("SPARKPOST_BASE_URL should not end with a '/',  SPARKPOST_BASE_URL=" + baseUrl + "");
+        if (this.baseUrl.endsWith("/")) {
+            throw new IllegalStateException("SPARKPOST_BASE_URL should not end with a '/',  SPARKPOST_BASE_URL=" + this.baseUrl + "");
         }
     }
 

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/transport/RestConnectionTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/transport/RestConnectionTest.java
@@ -1,0 +1,35 @@
+package com.sparkpost.transport;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class RestConnectionTest {
+
+    @Test
+    public void constructWithNullBaseURL() throws Exception {
+        RestConnection restConnection = new RestConnection(null, null);
+        assertEquals(IRestConnection.defaultApiEndpoint, restConnection.getBaseUrl());
+    }
+
+    @Test
+    public void constructWithEmptyBaseURL() throws Exception {
+        RestConnection restConnection = new RestConnection(null, "");
+        assertEquals(IRestConnection.defaultApiEndpoint, restConnection.getBaseUrl());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void constructWithInvalidBaseURL() throws Exception {
+        RestConnection restConnection = new RestConnection(null, "/");
+        assertEquals(IRestConnection.defaultApiEndpoint, restConnection.getBaseUrl());
+    }
+
+    @Test
+    public void constructWithValidBaseURL() throws Exception {
+        RestConnection restConnection = new RestConnection(null, "http://foo/bar");
+        assertNotEquals(IRestConnection.defaultApiEndpoint, restConnection.getBaseUrl());
+        assertEquals("http://foo/bar", restConnection.getBaseUrl());
+    }
+
+}


### PR DESCRIPTION
Should fix https://github.com/SparkPost/java-sparkpost/issues/75

Testing parameter instead of field results in NPE.

Replace reference to parameter with reference to field.
Create Tests
Add getter to test baseURL. This is final, so exposure should create minimal issues.