### PR TITLE
Switch to SLF4J

### DIFF
--- a/apps/sparkpost-documentor-app/pom.xml
+++ b/apps/sparkpost-documentor-app/pom.xml
@@ -15,10 +15,9 @@
 			<groupId>com.sparkpost</groupId>
 			<artifactId>sparkpost-lib</artifactId>
 		</dependency>
-
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/apps/sparkpost-javamail-app/pom.xml
+++ b/apps/sparkpost-javamail-app/pom.xml
@@ -19,6 +19,10 @@
 			<artifactId>sparkpost-lib</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.mail</groupId>
 			<artifactId>javax.mail-api</artifactId>
 			<version>1.5.5</version>

--- a/apps/sparkpost-javamail-app/src/main/java/com/sparkpost/sample/App.java
+++ b/apps/sparkpost-javamail-app/src/main/java/com/sparkpost/sample/App.java
@@ -20,9 +20,6 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
 import com.sparkpost.model.AddressAttributes;
@@ -41,8 +38,6 @@ import com.sparkpost.transport.RestConnection;
 public class App extends SparkPostBaseApp {
 
 	public static void main(String[] args) throws Exception {
-		Logger.getRootLogger().setLevel(Level.DEBUG);
-		
 		App app = new App();
 		app.runApp();
 	}

--- a/apps/sparkpost-samples-app/pom.xml
+++ b/apps/sparkpost-samples-app/pom.xml
@@ -16,10 +16,13 @@
 			<groupId>com.sparkpost</groupId>
 			<artifactId>sparkpost-lib</artifactId>
 		</dependency>
-
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/BadApiKeyErrorSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/BadApiKeyErrorSample.java
@@ -3,8 +3,8 @@ package com.sparkpost.error.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostAccessForbiddenException;
@@ -19,13 +19,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class BadApiKeyErrorSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(BadApiKeyErrorSample.class);
+    static final Logger logger = LoggerFactory.getLogger(BadApiKeyErrorSample.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         BadApiKeyErrorSample sample = new BadApiKeyErrorSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/ForceTransportError.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/ForceTransportError.java
@@ -3,8 +3,8 @@ package com.sparkpost.error.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostErrorServerResponseException;
@@ -17,13 +17,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class ForceTransportError extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(ForceTransportError.class);
+    static final Logger logger = LoggerFactory.getLogger(ForceTransportError.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         ForceTransportError app = new ForceTransportError();
         app.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/SendEmailErrorSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/SendEmailErrorSample.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostErrorServerResponseException;
@@ -25,13 +25,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailErrorSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(SendEmailErrorSample.class);
+    static final Logger logger = LoggerFactory.getLogger(SendEmailErrorSample.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         SendEmailErrorSample sample = new SendEmailErrorSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/SendInvalidFromAddress.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/SendInvalidFromAddress.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostErrorServerResponseException;
@@ -25,13 +25,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendInvalidFromAddress extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(SendInvalidFromAddress.class);
+    static final Logger logger = LoggerFactory.getLogger(SendInvalidFromAddress.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         SendInvalidFromAddress sample = new SendInvalidFromAddress();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateRecipientListSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateRecipientListSample.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -33,13 +33,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class CreateRecipientListSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         CreateRecipientListSample app = new CreateRecipientListSample();
         app.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateFromFile.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateFromFile.java
@@ -3,8 +3,8 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,13 +22,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class CreateTemplateFromFile extends SparkPostBaseApp {
 
-    private static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    private static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         CreateTemplateFromFile sample = new CreateTemplateFromFile();
         sample.runApp();
 

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateFromFile2.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateFromFile2.java
@@ -3,8 +3,8 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,13 +22,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class CreateTemplateFromFile2 extends SparkPostBaseApp {
 
-    private static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    private static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         CreateTemplateFromFile2 sample = new CreateTemplateFromFile2();
         sample.runApp();
 

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateSimple.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateSimple.java
@@ -1,10 +1,11 @@
+
 package com.sparkpost.samples;
 
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -19,54 +20,50 @@ import com.sparkpost.transport.RestConnection;
 
 public class CreateTemplateSimple extends SparkPostBaseApp {
 
-	private static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    private static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
-	private Client client;
-	
-	public static void main(String[] args) throws SparkPostException, IOException {
-		Logger.getRootLogger().setLevel(Level.DEBUG);
+    private Client client;
 
-		CreateTemplateSimple sample = new CreateTemplateSimple();
-		sample.runApp();
-		
-	}
-	
-	private void runApp() throws SparkPostException, IOException {
-		client = this.newConfiguredClient();
-		createTemplate();
-	}
-	
-	/**
-	 * Demonstrates how to store an email template in SparkPost
-	 * 
-	 * @throws SparkPostException
-	 */
-	public void createTemplate() throws SparkPostException {
-		if (logger.isDebugEnabled()) {
-			logger.debug("createTemplate()");
-		}
-		TemplateAttributes tpl = new TemplateAttributes();
+    public static void main(String[] args) throws SparkPostException, IOException {
+        CreateTemplateSimple sample = new CreateTemplateSimple();
+        sample.runApp();
 
-		tpl.setName(SAMPLE_TEMPLATE_NAME);
-		tpl.setContent(new TemplateContentAttributes());
-		tpl.getContent().setFrom(new AddressAttributes(client.getFromEmail(), "me", null));
-		tpl.getContent().setHtml("Hello!");
-		tpl.getContent().setSubject("Template Test");
-		IRestConnection connection = new RestConnection(client, getEndPoint());
-		Response response = ResourceTemplates.create(connection, tpl);
-		
-		if (logger.isDebugEnabled()) {
-			logger.debug("Create Template Response: " + response);
-		}
-	}
-	
-	public void sendEmail(String templateName, List<String> recipients) {
-		if (logger.isDebugEnabled()) {
-			logger.debug("sendEmail(...)");
-		}
-		
-	}
-	
-	
-	
+    }
+
+    private void runApp() throws SparkPostException, IOException {
+        this.client = this.newConfiguredClient();
+        createTemplate();
+    }
+
+    /**
+     * Demonstrates how to store an email template in SparkPost
+     * 
+     * @throws SparkPostException
+     */
+    public void createTemplate() throws SparkPostException {
+        if (logger.isDebugEnabled()) {
+            logger.debug("createTemplate()");
+        }
+        TemplateAttributes tpl = new TemplateAttributes();
+
+        tpl.setName(SAMPLE_TEMPLATE_NAME);
+        tpl.setContent(new TemplateContentAttributes());
+        tpl.getContent().setFrom(new AddressAttributes(this.client.getFromEmail(), "me", null));
+        tpl.getContent().setHtml("Hello!");
+        tpl.getContent().setSubject("Template Test");
+        IRestConnection connection = new RestConnection(this.client, getEndPoint());
+        Response response = ResourceTemplates.create(connection, tpl);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Create Template Response: " + response);
+        }
+    }
+
+    public void sendEmail(String templateName, List<String> recipients) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("sendEmail(...)");
+        }
+
+    }
+
 }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeleteSampleTemplates.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeleteSampleTemplates.java
@@ -4,8 +4,8 @@ package com.sparkpost.samples;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,13 +22,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class DeleteSampleTemplates extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(DeleteSampleTemplates.class);
+    static final Logger logger = LoggerFactory.getLogger(DeleteSampleTemplates.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         DeleteSampleTemplates sample = new DeleteSampleTemplates();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeleteWebhookSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeleteWebhookSample.java
@@ -3,8 +3,8 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -20,13 +20,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class DeleteWebhookSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         DeleteWebhookSample sample = new DeleteWebhookSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeliverabilityMetricsSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeliverabilityMetricsSample.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -33,11 +33,9 @@ public class DeliverabilityMetricsSample extends SparkPostBaseApp {
 
     private static final String FROM_DATE = "2014-07-11T08:00";
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         if (args.length == 0) {
             System.err.println("You must pass the metrics you want to querying");
             System.err.println("commands\n");

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllSendingDomains.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllSendingDomains.java
@@ -3,8 +3,8 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -19,13 +19,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class ListAllSendingDomains extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         ListAllSendingDomains sample = new ListAllSendingDomains();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllTemplatesSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllTemplatesSample.java
@@ -4,8 +4,8 @@ package com.sparkpost.samples;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -21,13 +21,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class ListAllTemplatesSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         ListAllTemplatesSample sample = new ListAllTemplatesSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllTransmissionsSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllTransmissionsSample.java
@@ -3,9 +3,6 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
 import com.sparkpost.model.TransmissionBase;
@@ -40,15 +37,13 @@ public class ListAllTransmissionsSample extends SparkPostBaseApp {
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         ListAllTransmissionsSample sample = new ListAllTransmissionsSample();
         sample.runApp();
 
     }
 
     private void runApp() throws SparkPostException, IOException {
-        client = this.newConfiguredClient();
+        this.client = this.newConfiguredClient();
         listAllTransmissions();
     }
 

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllWebhooksSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllWebhooksSample.java
@@ -3,8 +3,8 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -19,13 +19,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class ListAllWebhooksSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         ListAllWebhooksSample sample = new ListAllWebhooksSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/MandrillBlacklistImport.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/MandrillBlacklistImport.java
@@ -8,8 +8,8 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -26,7 +26,7 @@ import com.sparkpost.transport.RestConnection;
  */
 public class MandrillBlacklistImport extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(MandrillBlacklistImport.class);
+    static final Logger logger = LoggerFactory.getLogger(MandrillBlacklistImport.class);
 
     private Client client;
 
@@ -44,8 +44,6 @@ public class MandrillBlacklistImport extends SparkPostBaseApp {
     }
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         MandrillBlacklistImport sample = new MandrillBlacklistImport();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/MessageEventSearchSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/MessageEventSearchSample.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostErrorServerResponseException;
@@ -24,11 +24,9 @@ import com.sparkpost.transport.RestConnection;
  */
 public class MessageEventSearchSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     public static void main(String[] args) throws SparkPostException, IOException, InterruptedException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         MessageEventSearchSample app = new MessageEventSearchSample();
         app.doSearch();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/PreviewTemplateSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/PreviewTemplateSample.java
@@ -8,8 +8,8 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -29,13 +29,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class PreviewTemplateSample extends SparkPostBaseApp {
 
-    private static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    private static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         PreviewTemplateSample sample = new PreviewTemplateSample();
         sample.runApp();
 

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/RetrieveAllTemplatesSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/RetrieveAllTemplatesSample.java
@@ -4,8 +4,8 @@ package com.sparkpost.samples;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,13 +22,11 @@ import com.sparkpost.transport.RestConnection;
  */
 public class RetrieveAllTemplatesSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         RetrieveAllTemplatesSample sample = new RetrieveAllTemplatesSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SampleApplication.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SampleApplication.java
@@ -5,8 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -34,9 +32,6 @@ public class SampleApplication {
     private static Gson gson;
 
     public static void main(String[] args) throws SparkPostException {
-        // Set to DEBUG so we can see what the SparkPost SDK is doing:
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         // Initialize our JSON parser. We'll use it to parse responses from
         // the SparkPost server.
         GsonBuilder gsonBuilder = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss");

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailBCCSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailBCCSample.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,13 +22,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailBCCSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         SendEmailBCCSample sample = new SendEmailBCCSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailCCSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailCCSample.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,13 +24,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailCCSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         SendEmailCCSample sample = new SendEmailCCSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailRecipientListSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailRecipientListSample.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,13 +22,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailRecipientListSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         SendEmailRecipientListSample sample = new SendEmailRecipientListSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailSample.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,13 +24,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         SendEmailSample sample = new SendEmailSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithFilesSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithFilesSample.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,13 +24,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailWithFilesSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         SendEmailWithFilesSample sample = new SendEmailWithFilesSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithSubstitutionSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithSubstitutionSample.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,13 +24,11 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailWithSubstitutionSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(SendEmailWithSubstitutionSample.class);
+    static final Logger logger = LoggerFactory.getLogger(SendEmailWithSubstitutionSample.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-
         SendEmailWithSubstitutionSample sample = new SendEmailWithSubstitutionSample();
         sample.runApp();
     }

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/sdk/samples/helpers/SparkPostBaseApp.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/sdk/samples/helpers/SparkPostBaseApp.java
@@ -11,8 +11,8 @@ import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -29,11 +29,10 @@ public class SparkPostBaseApp {
 
     private final Properties properties = new Properties();
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LoggerFactory.getLogger(CreateTemplateSimple.class);
 
     public SparkPostBaseApp() {
         super();
-        BasicConfigurator.configure();
         this.loadProperties();
     }
 
@@ -49,7 +48,7 @@ public class SparkPostBaseApp {
         }
 
         if (logger.isDebugEnabled()) {
-            logger.debug(client);
+            logger.debug(client.toString());
         }
 
         return client;

--- a/libs/sparkpost-lib/log4j.xml
+++ b/libs/sparkpost-lib/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="console" class="org.apache.log4j.ConsoleAppender"> 
+    <param name="Target" value="System.out"/> 
+    <layout class="org.apache.log4j.PatternLayout"> 
+      <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/> 
+    </layout> 
+  </appender> 
+
+  <root> 
+    <priority value ="debug" /> 
+    <appender-ref ref="console" /> 
+  </root>
+  
+</log4j:configuration>

--- a/libs/sparkpost-lib/pom.xml
+++ b/libs/sparkpost-lib/pom.xml
@@ -13,10 +13,14 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
@@ -13,7 +13,8 @@ import java.net.URL;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sparkpost.Build;
 import com.sparkpost.Client;
@@ -33,7 +34,7 @@ import lombok.Getter;
  */
 public class RestConnection implements IRestConnection {
 
-    private static final Logger logger = Logger.getLogger(RestConnection.class);
+    private static final Logger logger = LoggerFactory.getLogger(RestConnection.class);
 
     private static final String VERSION = Build.VERSION + " (" + Build.GIT_SHORT_HASH + ")";
 

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/EndPointTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/EndPointTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sparkpost.resources.Endpoint;
@@ -15,11 +12,6 @@ import com.sparkpost.resources.Endpoint;
 public class EndPointTest {
 
     public EndPointTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
     }
 
     @AfterClass
@@ -85,7 +77,7 @@ public class EndPointTest {
     @Test
     public void testEndPointWithBoolean() {
         Endpoint endPoint = new Endpoint("transmissions");
-        endPoint.addParam("myBool", new Boolean(true));
+        endPoint.addParam("myBool", Boolean.TRUE);
 
         String result = endPoint.toString();
         Assert.assertEquals("/transmissions?myBool=true", result);
@@ -97,7 +89,7 @@ public class EndPointTest {
     @Test
     public void testEndPointWithInteger() {
         Endpoint endPoint = new Endpoint("transmissions");
-        endPoint.addParam("myInteger", new Integer(100));
+        endPoint.addParam("myInteger", Integer.valueOf(100));
 
         String result = endPoint.toString();
         Assert.assertEquals("/transmissions?myInteger=100", result);
@@ -110,8 +102,8 @@ public class EndPointTest {
     public void testEndPointWithMultipleParameters() {
         Endpoint endPoint = new Endpoint("transmissions");
         endPoint.addParam("num_rcpt_errors", 3);
-        endPoint.addParam("myBool", new Boolean(false));
-        endPoint.addParam("MyInteger", new Integer(0));
+        endPoint.addParam("myBool", Boolean.FALSE);
+        endPoint.addParam("MyInteger", Integer.valueOf(0));
 
         String result = endPoint.toString();
         Assert.assertEquals("/transmissions?num_rcpt_errors=3&myBool=false&MyInteger=0", result);

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/AddressAttributesTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/AddressAttributesTests.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -21,11 +18,6 @@ public class AddressAttributesTests {
             + "\"header_to\" : \"some header to\","
             + "\"name\" : \"First Last\""
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DKIMResultsTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DKIMResultsTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -30,11 +27,6 @@ public class DKIMResultsTest {
             + "      \"selector\": \"hello_selector\"\n"
             + "    }\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DKIMTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DKIMTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -20,11 +17,6 @@ public class DKIMTest {
             + "      \"private\": \"some private key\",\n"
             + "      \"selector\": \"hello_selector\"\n"
             + "    }";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DNSAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DNSAttributesTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -20,11 +17,6 @@ public class DNSAttributesTest {
             + "      \"dkim_error\": \"some dkim error\",\n"
             + "      \"spf_error\": \"some spf error\"\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/MessageEventsQueryBuilderTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/MessageEventsQueryBuilderTest.java
@@ -3,24 +3,16 @@ package com.sparkpost.model;
 
 import java.net.URISyntaxException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sparkpost.model.MessageEventsQueryBuilder.BounceClass;
 import com.sparkpost.resources.Endpoint;
 
 public class MessageEventsQueryBuilderTest {
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/OptionsAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/OptionsAttributesTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -23,11 +20,6 @@ public class OptionsAttributesTest {
             + "      \"skip_suppression\": true,\n"
             + "      \"ip_pool\":\"sp_shared\"\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientAttributesTest.java
@@ -5,15 +5,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -42,11 +39,6 @@ public class RecipientAttributesTest {
             + "    }";
 
     private List<String> expected = Arrays.asList("greeting", "prehistoric", "fred", "flintstone");
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientListTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientListTest.java
@@ -4,13 +4,10 @@ package com.sparkpost.model;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -79,11 +76,6 @@ public class RecipientListTest {
             + "}";
 
     //private List<String> expected = Arrays.asList("greeting", "prehistoric", "fred", "flintstone");
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SendingDomainTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SendingDomainTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -15,11 +12,6 @@ import com.google.gson.Gson;
 public class SendingDomainTest {
 
     private String SENDING_DOMAIN_JSON = "{\n" + "    \"domain\": \"domain.com\",\n" + "    \"status\": { },\n" + "    \"dkim\": { }\n" + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StatusAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StatusAttributesTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -22,11 +19,6 @@ public class StatusAttributesTest {
             + "     \"compliance_status\": \"pending\",\n"
             + "     \"postmaster_at_status\": \"pending\"\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StoredRecipientListTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StoredRecipientListTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -15,11 +12,6 @@ import com.google.gson.Gson;
 public class StoredRecipientListTest {
 
     private String STORED_RECIPIENT_LIST_JSON = "{ \"list_id\":\"123412341234\" }";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StoredTemplateTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StoredTemplateTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -18,11 +15,6 @@ public class StoredTemplateTest {
             + "                \"template_id\": \"christmas_offer\",\n"
             + "                \"use_draft_template\": true\n"
             + "              }";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SuppressionListEntryTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SuppressionListEntryTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -20,11 +17,6 @@ public class SuppressionListEntryTest {
             + "            \"source\": \"some source\",\n"
             + "            \"description\": \"User requested to not receive any transactional emails.\"\n"
             + "          }";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SuppressionListTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SuppressionListTest.java
@@ -3,13 +3,10 @@ package com.sparkpost.model;
 
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -29,11 +26,6 @@ public class SuppressionListTest {
             + "          }\n"
             + "      ]\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TemplateAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TemplateAttributesTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -42,11 +39,6 @@ public class TemplateAttributesTest {
             + "            }\n"
             + "          }\n"
             + "        } ";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TemplateContentAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TemplateContentAttributesTest.java
@@ -3,13 +3,10 @@ package com.sparkpost.model;
 
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -30,11 +27,6 @@ public class TemplateContentAttributesTest {
             + "              \"name\" : \"First Last\""
             + "          }"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TransmissionWithRecipientArrayTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TransmissionWithRecipientArrayTest.java
@@ -4,13 +4,10 @@ package com.sparkpost.model;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -69,11 +66,6 @@ public class TransmissionWithRecipientArrayTest {
             + "            \"html\": \"<p>Hi {{address.name}} \\nSave big this Christmas in your area {{place}}! \\nClick http://www.mysite.com and get huge discount\\n</p><p>Hurry, this offer is only to {{user_type}}\\n</p><p>{{sender}}</p>\"\n"
             + "          }\n"
             + "        }";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/VerifyResponseTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/VerifyResponseTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -31,11 +28,6 @@ public class VerifyResponseTest {
             + "    }\n"
             + "  }\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/BounceEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/BounceEventTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -45,11 +42,6 @@ public class BounceEventTest {
             + "    \"rcpt_tags\": [],\n"
             + "    \"raw_rcpt_to\": \"nonExist@example.com\"\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/ClickEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/ClickEventTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -34,11 +31,6 @@ public class ClickEventTest {
             + "    \"customer_id\": \"1\",\n"
             + "    \"template_version\": \"1\"\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/DelayEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/DelayEventTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -43,11 +40,6 @@ public class DelayEventTest {
             + "        \"rcpt_tags\": [],\n"
             + "        \"raw_rcpt_to\": \"test@example.com\"\n"
             + "      }";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/DeliveryEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/DeliveryEventTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -36,11 +33,6 @@ public class DeliveryEventTest {
             + "    \"rcpt_to\": \"test@example.com\",\n"
             + "    \"raw_rcpt_to\": \"test@example.com\"\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/GenerationFailureEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/GenerationFailureEventTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -38,11 +35,6 @@ public class GenerationFailureEventTest {
             + "                \"rcpt_tags\": [\n"
             + "                ]\n"
             + "            }";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/GenerationRejectionEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/GenerationRejectionEventTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -35,11 +32,6 @@ public class GenerationRejectionEventTest {
             + "    \"binding_group\": \"default\",\n"
             + "    \"rcpt_meta\": {}\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/InjectionEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/InjectionEventTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -36,11 +33,6 @@ public class InjectionEventTest {
             + "        \"campaign_id\": \"test\",\n"
             + "        \"raw_rcpt_to\": \"test@example.com\"\n"
             + "      }";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/OpenEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/OpenEventTest.java
@@ -1,13 +1,10 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -43,11 +40,6 @@ public class OpenEventTest {
             + "    },\n"
             + "    \"raw_rcpt_to\": \"test@example.com\"\n"
             + "}";
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceMetricTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceMetricTests.java
@@ -3,13 +3,10 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sparkpost.exception.SparkPostException;
@@ -18,11 +15,6 @@ import com.sparkpost.model.responses.Response;
 import com.sparkpost.testhelpers.StubRestConnection;
 
 public class ResourceMetricTests extends BaseResourceTest {
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceRecipientListsTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceRecipientListsTests.java
@@ -3,13 +3,10 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sparkpost.exception.SparkPostException;
@@ -20,11 +17,6 @@ import com.sparkpost.model.responses.Response;
 import com.sparkpost.testhelpers.StubRestConnection;
 
 public class ResourceRecipientListsTests extends BaseResourceTest {
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceSendingDomainsTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceSendingDomainsTests.java
@@ -3,13 +3,10 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sparkpost.exception.SparkPostException;
@@ -19,11 +16,6 @@ import com.sparkpost.model.responses.Response;
 import com.sparkpost.testhelpers.StubRestConnection;
 
 public class ResourceSendingDomainsTests extends BaseResourceTest {
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceSuppressionListTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceSuppressionListTests.java
@@ -3,13 +3,10 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sparkpost.exception.SparkPostException;
@@ -19,11 +16,6 @@ import com.sparkpost.model.responses.Response;
 import com.sparkpost.testhelpers.StubRestConnection;
 
 public class ResourceSuppressionListTests extends BaseResourceTest {
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceTemplatesTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceTemplatesTests.java
@@ -3,13 +3,10 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sparkpost.exception.SparkPostException;
@@ -23,11 +20,6 @@ import com.sparkpost.model.responses.TemplateRetrieveResponse;
 import com.sparkpost.testhelpers.StubRestConnection;
 
 public class ResourceTemplatesTests extends BaseResourceTest {
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceTransmissionsTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceTransmissionsTests.java
@@ -3,13 +3,10 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sparkpost.exception.SparkPostException;
@@ -22,11 +19,6 @@ import com.sparkpost.model.responses.TransmissionRetrieveResults;
 import com.sparkpost.testhelpers.StubRestConnection;
 
 public class ResourceTransmissionsTests extends BaseResourceTest {
-
-    @BeforeClass
-    public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
-    }
 
     @AfterClass
     public static void tearDownClass() {

--- a/pom.xml
+++ b/pom.xml
@@ -217,14 +217,14 @@
 		<dependencies>
 			<!-- THIRD PARTY LIBRARIES -->
 			<dependency>
-				<groupId>log4j</groupId>
-				<artifactId>log4j</artifactId>
-				<version>1.2.17</version>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>1.7.25</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-api</artifactId>
-				<version>1.7.12</version>
+				<artifactId>slf4j-log4j12</artifactId>
+				<version>1.7.25</version>
 			</dependency>
 			<dependency>
 				<groupId>com.googlecode.jmockit</groupId>


### PR DESCRIPTION
This will utilize the SLF4J API dependency everywhere. This will include the SLF4J log4j dependency for the sample applications so they continue to log using the provided log4j.properties or log4j.xml files.

This PR is for issue #86