### PR TITLE
[ISSUE-103]: Migrate away from log4j 1.x

### DIFF
--- a/apps/sparkpost-documentor-app/log4j.properties
+++ b/apps/sparkpost-documentor-app/log4j.properties
@@ -1,10 +1,10 @@
 # Root logger option
-log4j.rootLogger=DEBUG, stdout
+log4j.rootLogger=DEBUG, STDOUT
 
 # Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout=org.apache.logging.log4j.ConsoleAppender
+log4j.appender.stdout.Target=SYSTEM_OUT
+log4j.appender.stdout.layout=org.apache.logging.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 

--- a/apps/sparkpost-documentor-app/pom.xml
+++ b/apps/sparkpost-documentor-app/pom.xml
@@ -17,9 +17,13 @@
 		</dependency>
 
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/apps/sparkpost-javamail-app/log4j.xml
+++ b/apps/sparkpost-javamail-app/log4j.xml
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<Configuration>
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%-5p %c{1} - %m%n"/>
+        </Console>
 
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-  <appender name="console" class="org.apache.log4j.ConsoleAppender"> 
-    <param name="Target" value="System.out"/> 
-    <layout class="org.apache.log4j.PatternLayout"> 
-      <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/> 
-    </layout> 
-  </appender> 
-
-  <root> 
-    <priority value ="debug" /> 
-    <appender-ref ref="console" /> 
-  </root>
-  
-</log4j:configuration>
+        <RollingFile name="testFile" fileName="/logs/testing.log">
+            <PatternLayout pattern="%-5p %c{1} - %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="20 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="testFile"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/apps/sparkpost-javamail-app/src/main/java/com/sparkpost/sample/App.java
+++ b/apps/sparkpost-javamail-app/src/main/java/com/sparkpost/sample/App.java
@@ -20,8 +20,8 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.Level;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -41,8 +41,8 @@ import com.sparkpost.transport.RestConnection;
 public class App extends SparkPostBaseApp {
 
 	public static void main(String[] args) throws Exception {
-		Logger.getRootLogger().setLevel(Level.DEBUG);
-		
+        Configurator.setRootLevel(Level.DEBUG);
+
 		App app = new App();
 		app.runApp();
 	}

--- a/apps/sparkpost-samples-app/log4j.properties
+++ b/apps/sparkpost-samples-app/log4j.properties
@@ -1,10 +1,10 @@
 # Root logger option
-log4j.rootLogger=DEBUG, stdout
+log4j.rootLogger=DEBUG, STDOUT
 
 # Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout=org.apache.logging.log4j.ConsoleAppender
+log4j.appender.stdout.Target=SYSTEM_OUT
+log4j.appender.stdout.layout=org.apache.logging.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 

--- a/apps/sparkpost-samples-app/pom.xml
+++ b/apps/sparkpost-samples-app/pom.xml
@@ -16,11 +16,14 @@
 			<groupId>com.sparkpost</groupId>
 			<artifactId>sparkpost-lib</artifactId>
 		</dependency>
-
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/BadApiKeyErrorSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/BadApiKeyErrorSample.java
@@ -3,8 +3,10 @@ package com.sparkpost.error.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostAccessForbiddenException;
@@ -19,12 +21,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class BadApiKeyErrorSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(BadApiKeyErrorSample.class);
+    static final Logger logger = LogManager.getLogger(BadApiKeyErrorSample.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         BadApiKeyErrorSample sample = new BadApiKeyErrorSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/ForceTransportError.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/ForceTransportError.java
@@ -3,8 +3,10 @@ package com.sparkpost.error.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostErrorServerResponseException;
@@ -17,12 +19,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class ForceTransportError extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(ForceTransportError.class);
+    static final Logger logger = LogManager.getLogger(ForceTransportError.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         ForceTransportError app = new ForceTransportError();
         app.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/SendEmailErrorSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/SendEmailErrorSample.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostErrorServerResponseException;
@@ -25,12 +27,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailErrorSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(SendEmailErrorSample.class);
+    static final Logger logger = LogManager.getLogger(SendEmailErrorSample.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendEmailErrorSample sample = new SendEmailErrorSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/SendInvalidFromAddress.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/error/samples/SendInvalidFromAddress.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostErrorServerResponseException;
@@ -25,12 +27,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendInvalidFromAddress extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(SendInvalidFromAddress.class);
+    static final Logger logger = LogManager.getLogger(SendInvalidFromAddress.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendInvalidFromAddress sample = new SendInvalidFromAddress();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateRecipientListSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateRecipientListSample.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -33,12 +35,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class CreateRecipientListSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         CreateRecipientListSample app = new CreateRecipientListSample();
         app.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateFromFile.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateFromFile.java
@@ -3,8 +3,9 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -15,6 +16,7 @@ import com.sparkpost.resources.ResourceTemplates;
 import com.sparkpost.sdk.samples.helpers.SparkPostBaseApp;
 import com.sparkpost.transport.IRestConnection;
 import com.sparkpost.transport.RestConnection;
+import org.apache.logging.log4j.core.config.Configurator;
 
 /**
  * This class demonstrates how to store and RFC822 template in SparkPost
@@ -22,12 +24,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class CreateTemplateFromFile extends SparkPostBaseApp {
 
-    private static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    private static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         CreateTemplateFromFile sample = new CreateTemplateFromFile();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateFromFile2.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateFromFile2.java
@@ -3,8 +3,10 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,12 +24,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class CreateTemplateFromFile2 extends SparkPostBaseApp {
 
-    private static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    private static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         CreateTemplateFromFile2 sample = new CreateTemplateFromFile2();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateSimple.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/CreateTemplateSimple.java
@@ -3,8 +3,10 @@ package com.sparkpost.samples;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -19,12 +21,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class CreateTemplateSimple extends SparkPostBaseApp {
 
-	private static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+	private static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
 	private Client client;
 	
 	public static void main(String[] args) throws SparkPostException, IOException {
-		Logger.getRootLogger().setLevel(Level.DEBUG);
+		Configurator.setRootLevel(Level.DEBUG);
 
 		CreateTemplateSimple sample = new CreateTemplateSimple();
 		sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeleteSampleTemplates.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeleteSampleTemplates.java
@@ -4,8 +4,9 @@ package com.sparkpost.samples;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -16,18 +17,19 @@ import com.sparkpost.resources.ResourceTemplates;
 import com.sparkpost.sdk.samples.helpers.SparkPostBaseApp;
 import com.sparkpost.transport.IRestConnection;
 import com.sparkpost.transport.RestConnection;
+import org.apache.logging.log4j.core.config.Configurator;
 
 /**
  * Delete all test templates created by the sample code
  */
 public class DeleteSampleTemplates extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(DeleteSampleTemplates.class);
+    static final Logger logger = LogManager.getLogger(DeleteSampleTemplates.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         DeleteSampleTemplates sample = new DeleteSampleTemplates();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeleteWebhookSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeleteWebhookSample.java
@@ -3,8 +3,9 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -14,18 +15,19 @@ import com.sparkpost.resources.ResourceWebhooks;
 import com.sparkpost.sdk.samples.helpers.SparkPostBaseApp;
 import com.sparkpost.transport.IRestConnection;
 import com.sparkpost.transport.RestConnection;
+import org.apache.logging.log4j.core.config.Configurator;
 
 /**
  * Delete all webhooks with "deleteme" in their name
  */
 public class DeleteWebhookSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         DeleteWebhookSample sample = new DeleteWebhookSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeliverabilityMetricsSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/DeliverabilityMetricsSample.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -33,10 +35,10 @@ public class DeliverabilityMetricsSample extends SparkPostBaseApp {
 
     private static final String FROM_DATE = "2014-07-11T08:00";
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         if (args.length == 0) {
             System.err.println("You must pass the metrics you want to querying");

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllSendingDomains.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllSendingDomains.java
@@ -3,8 +3,10 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -19,12 +21,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class ListAllSendingDomains extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         ListAllSendingDomains sample = new ListAllSendingDomains();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllTemplatesSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllTemplatesSample.java
@@ -4,8 +4,10 @@ package com.sparkpost.samples;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -21,12 +23,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class ListAllTemplatesSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         ListAllTemplatesSample sample = new ListAllTemplatesSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllTransmissionsSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllTransmissionsSample.java
@@ -3,8 +3,7 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -15,6 +14,7 @@ import com.sparkpost.resources.ResourceTransmissions;
 import com.sparkpost.sdk.samples.helpers.SparkPostBaseApp;
 import com.sparkpost.transport.IRestConnection;
 import com.sparkpost.transport.RestConnection;
+import org.apache.logging.log4j.core.config.Configurator;
 
 /**
  * List an array of transmission summary objects. A transmission summary object
@@ -40,7 +40,7 @@ public class ListAllTransmissionsSample extends SparkPostBaseApp {
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         ListAllTransmissionsSample sample = new ListAllTransmissionsSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllWebhooksSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/ListAllWebhooksSample.java
@@ -3,8 +3,10 @@ package com.sparkpost.samples;
 
 import java.io.IOException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -19,12 +21,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class ListAllWebhooksSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         ListAllWebhooksSample sample = new ListAllWebhooksSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/MandrillBlacklistImport.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/MandrillBlacklistImport.java
@@ -8,8 +8,10 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -26,7 +28,7 @@ import com.sparkpost.transport.RestConnection;
  */
 public class MandrillBlacklistImport extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(MandrillBlacklistImport.class);
+    static final Logger logger = LogManager.getLogger(MandrillBlacklistImport.class);
 
     private Client client;
 
@@ -44,7 +46,7 @@ public class MandrillBlacklistImport extends SparkPostBaseApp {
     }
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         MandrillBlacklistImport sample = new MandrillBlacklistImport();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/MessageEventSearchSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/MessageEventSearchSample.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostErrorServerResponseException;
@@ -24,10 +26,10 @@ import com.sparkpost.transport.RestConnection;
  */
 public class MessageEventSearchSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     public static void main(String[] args) throws SparkPostException, IOException, InterruptedException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         MessageEventSearchSample app = new MessageEventSearchSample();
         app.doSearch();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/PreviewTemplateSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/PreviewTemplateSample.java
@@ -8,8 +8,10 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -29,12 +31,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class PreviewTemplateSample extends SparkPostBaseApp {
 
-    private static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    private static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         PreviewTemplateSample sample = new PreviewTemplateSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/RetrieveAllTemplatesSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/RetrieveAllTemplatesSample.java
@@ -4,8 +4,10 @@ package com.sparkpost.samples;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,12 +24,12 @@ import com.sparkpost.transport.RestConnection;
  */
 public class RetrieveAllTemplatesSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         RetrieveAllTemplatesSample sample = new RetrieveAllTemplatesSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SampleApplication.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SampleApplication.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -35,7 +35,7 @@ public class SampleApplication {
 
     public static void main(String[] args) throws SparkPostException {
         // Set to DEBUG so we can see what the SparkPost SDK is doing:
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         // Initialize our JSON parser. We'll use it to parse responses from
         // the SparkPost server.

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendAmpEmailSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendAmpEmailSample.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,12 +26,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendAmpEmailSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendAmpEmailSample sample = new SendAmpEmailSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailBCCSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailBCCSample.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,12 +24,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailBCCSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendEmailBCCSample sample = new SendEmailBCCSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailCCSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailCCSample.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,12 +26,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailCCSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendEmailCCSample sample = new SendEmailCCSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailRecipientListSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailRecipientListSample.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -22,12 +24,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailRecipientListSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendEmailRecipientListSample sample = new SendEmailRecipientListSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailSample.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,12 +26,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendEmailSample sample = new SendEmailSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailTemplateSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailTemplateSample.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,12 +26,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailTemplateSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendEmailTemplateSample sample = new SendEmailTemplateSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithFilesSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithFilesSample.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,12 +26,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailWithFilesSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendEmailWithFilesSample sample = new SendEmailWithFilesSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithSubstitutionSample.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/samples/SendEmailWithSubstitutionSample.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
@@ -24,12 +26,12 @@ import com.sparkpost.transport.RestConnection;
 
 public class SendEmailWithSubstitutionSample extends SparkPostBaseApp {
 
-    static final Logger logger = Logger.getLogger(SendEmailWithSubstitutionSample.class);
+    static final Logger logger = LogManager.getLogger(SendEmailWithSubstitutionSample.class);
 
     private Client client;
 
     public static void main(String[] args) throws SparkPostException, IOException {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
 
         SendEmailWithSubstitutionSample sample = new SendEmailWithSubstitutionSample();
         sample.runApp();

--- a/apps/sparkpost-samples-app/src/main/java/com/sparkpost/sdk/samples/helpers/SparkPostBaseApp.java
+++ b/apps/sparkpost-samples-app/src/main/java/com/sparkpost/sdk/samples/helpers/SparkPostBaseApp.java
@@ -11,9 +11,10 @@ import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Logger;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import com.sparkpost.Client;
 import com.sparkpost.exception.SparkPostException;
 import com.sparkpost.samples.CreateTemplateSimple;
@@ -29,11 +30,11 @@ public class SparkPostBaseApp {
 
     private final Properties properties = new Properties();
 
-    static final Logger logger = Logger.getLogger(CreateTemplateSimple.class);
+    static final Logger logger = LogManager.getLogger(CreateTemplateSimple.class);
 
     public SparkPostBaseApp() {
         super();
-        BasicConfigurator.configure();
+        Configurator.initialize(new DefaultConfiguration());
         this.loadProperties();
     }
 

--- a/libs/sparkpost-lib/pom.xml
+++ b/libs/sparkpost-lib/pom.xml
@@ -13,10 +13,13 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
 		</dependency>
-
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
+++ b/libs/sparkpost-lib/src/main/java/com/sparkpost/transport/RestConnection.java
@@ -17,7 +17,8 @@ import java.util.Set;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.sparkpost.Build;
 import com.sparkpost.Client;
@@ -37,7 +38,7 @@ import lombok.Getter;
  */
 public class RestConnection implements IRestConnection {
 
-    private static final Logger logger = Logger.getLogger(RestConnection.class);
+    private static final Logger logger = LogManager.getLogger(RestConnection.class);
 
     private static final String VERSION = Build.VERSION + " (" + Build.GIT_SHORT_HASH + ")";
 

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/EndPointTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/EndPointTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -19,7 +19,7 @@ public class EndPointTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/AddressAttributesTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/AddressAttributesTests.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -24,7 +24,7 @@ public class AddressAttributesTests {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DKIMResultsTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DKIMResultsTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -33,7 +33,7 @@ public class DKIMResultsTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DKIMTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DKIMTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -23,7 +23,7 @@ public class DKIMTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DNSAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/DNSAttributesTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -23,7 +23,7 @@ public class DNSAttributesTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/MessageEventsQueryBuilderTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/MessageEventsQueryBuilderTest.java
@@ -3,8 +3,8 @@ package com.sparkpost.model;
 
 import java.net.URISyntaxException;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -19,7 +19,7 @@ public class MessageEventsQueryBuilderTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/OptionsAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/OptionsAttributesTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -26,7 +26,7 @@ public class OptionsAttributesTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientAttributesTest.java
@@ -5,8 +5,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -45,7 +45,7 @@ public class RecipientAttributesTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientListTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/RecipientListTest.java
@@ -4,8 +4,8 @@ package com.sparkpost.model;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -82,7 +82,7 @@ public class RecipientListTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SendingDomainTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SendingDomainTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -18,7 +18,7 @@ public class SendingDomainTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StatusAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StatusAttributesTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -25,7 +25,7 @@ public class StatusAttributesTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StoredRecipientListTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StoredRecipientListTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -18,7 +18,7 @@ public class StoredRecipientListTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StoredTemplateTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/StoredTemplateTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -21,7 +21,7 @@ public class StoredTemplateTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SuppressionListEntryTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SuppressionListEntryTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -23,7 +23,7 @@ public class SuppressionListEntryTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SuppressionListTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/SuppressionListTest.java
@@ -3,8 +3,8 @@ package com.sparkpost.model;
 
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -32,7 +32,7 @@ public class SuppressionListTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TemplateAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TemplateAttributesTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -45,7 +45,7 @@ public class TemplateAttributesTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TemplateContentAttributesTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TemplateContentAttributesTest.java
@@ -3,8 +3,8 @@ package com.sparkpost.model;
 
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -33,7 +33,7 @@ public class TemplateContentAttributesTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TransmissionWithRecipientArrayTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/TransmissionWithRecipientArrayTest.java
@@ -4,8 +4,8 @@ package com.sparkpost.model;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -72,7 +72,7 @@ public class TransmissionWithRecipientArrayTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/VerifyResponseTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/VerifyResponseTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -34,7 +34,7 @@ public class VerifyResponseTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/BounceEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/BounceEventTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -48,7 +48,7 @@ public class BounceEventTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/ClickEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/ClickEventTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -37,7 +37,7 @@ public class ClickEventTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/DelayEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/DelayEventTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -46,7 +46,7 @@ public class DelayEventTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/DeliveryEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/DeliveryEventTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -39,7 +39,7 @@ public class DeliveryEventTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/GenerationFailureEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/GenerationFailureEventTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -41,7 +41,7 @@ public class GenerationFailureEventTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/GenerationRejectionEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/GenerationRejectionEventTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -38,7 +38,7 @@ public class GenerationRejectionEventTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/InjectionEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/InjectionEventTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -39,7 +39,7 @@ public class InjectionEventTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/OpenEventTest.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/model/webhook/event/OpenEventTest.java
@@ -1,8 +1,8 @@
 
 package com.sparkpost.model.webhook.event;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -46,7 +46,7 @@ public class OpenEventTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceMetricTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceMetricTests.java
@@ -3,8 +3,8 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -21,7 +21,7 @@ public class ResourceMetricTests extends BaseResourceTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceRecipientListsTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceRecipientListsTests.java
@@ -3,8 +3,8 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -23,7 +23,7 @@ public class ResourceRecipientListsTests extends BaseResourceTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceSendingDomainsTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceSendingDomainsTests.java
@@ -3,8 +3,8 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -22,7 +22,7 @@ public class ResourceSendingDomainsTests extends BaseResourceTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceSuppressionListTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceSuppressionListTests.java
@@ -3,8 +3,8 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -22,7 +22,7 @@ public class ResourceSuppressionListTests extends BaseResourceTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceTemplatesTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceTemplatesTests.java
@@ -3,8 +3,8 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -26,7 +26,7 @@ public class ResourceTemplatesTests extends BaseResourceTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceTransmissionsTests.java
+++ b/libs/sparkpost-lib/src/test/java/com/sparkpost/resources/ResourceTransmissionsTests.java
@@ -3,8 +3,8 @@ package com.sparkpost.resources;
 
 import java.lang.reflect.Type;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -25,7 +25,7 @@ public class ResourceTransmissionsTests extends BaseResourceTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Logger.getRootLogger().setLevel(Level.DEBUG);
+        Configurator.setRootLevel(Level.DEBUG);
     }
 
     @AfterClass

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
 									<pluginExecutionFilter>
 										<groupId>org.codehaus.mojo</groupId>
 										<artifactId>findbugs-maven-plugin</artifactId>
-										<versionRange>[3.0.2,)</versionRange>
+										<versionRange>[3.0.4,)</versionRange>
 										<goals>
 											<goal>check</goal>
 										</goals>
@@ -193,7 +193,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.2</version>
+				<version>3.0.4</version>
 				<configuration>
 					<excludeFilterFile>${basedir}/../../findbugs-exclude.xml</excludeFilterFile>
 				</configuration>
@@ -216,11 +216,16 @@
 
 		<dependencies>
 			<!-- THIRD PARTY LIBRARIES -->
-			<dependency>
-				<groupId>log4j</groupId>
-				<artifactId>log4j</artifactId>
-				<version>1.2.17</version>
-			</dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>2.14.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.14.1</version>
+            </dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
[ISSUE-103](https://github.com/SparkPost/java-sparkpost/issues/103)

## Description of the fix:
The following points were considered before coming up with the solution:
- This vulnerability doesn't exit in log4j version >= 2.8.2. Click [here](https://nsfocusglobal.com/apache-log4j-deserialization-remote-code-execution-cve-2019-17571-vulnerability-threat-alert/) for reference 
- Apart from the vulnerability the project was also using the deprecated log4j version 1.x, which has other vulnerabilities

**Solution**:
As an overall solution to fix log4j related vulnerabilities, i have updated the log4j package to recent stable 2.x version. This [migration document](https://logging.apache.org/log4j/2.x/manual/migration.html) provided by the official website was used as an overall reference.

## File changes made
### Added
- included maven dependency for 2.14.1 version of log4j-core and log4j-1.2-api to include imports from these libraries

### Changed
- Updated log4j.xml configuration to the format accepted by log4j2 version
- Replaced maven dependency reference of log4j with log4j2 in libs/sparkpost-lib/pom.xml and apps/sparkpost-documentor-app/pom.xml
- Replaced deprecated `Logger.getLogger` command with `LogManager.getLogger` command in classes belonging to `apps/sparkpost-samples-app/src/main/java/com/sparkpost` package. 
  - Click [here](https://logging.apache.org/log4j/2.x/manual/migration.html) for this solution reference
- Replaced deprecated `Logger.getRootLogger().setLevel` command with `Configurator.setRootLevel` command upon migration in all of the BeforeClass methods in the integration tests and in classes belonging to `apps/sparkpost-samples-app/src/main/java/com/sparkpost` package. 
  - Click [here](https://stackoverflow.com/questions/23434252/programmatically-change-log-level-in-log4j2#:~:text=If%20you%20wish%20to%20change,getConfiguration()%3B%20LoggerConfig%20loggerConfig%20%3D%20config.) for this solution reference
- Updated log4j.properties to refer to newly included log4j2 package for appender type, target and log pattern
- Replaced deprecated `BasicConfigurator.configure()` command with `Configurator.initialize(new DefaultConfiguration())` command in helpers/SparkPostBaseApp.java file. 
  - Click [here](https://stackoverflow.com/questions/41442024/basicconfigurator-replacement-in-log4j2) for this solution reference

### Testing done
- Checked if `mvn clean install` command runs successfully and tests are all passing on migration
<img width="1440" alt="Screenshot 2021-07-24 at 7 07 25 PM" src="https://user-images.githubusercontent.com/67866345/126871024-6b74658e-85f7-444a-99e8-b461a47e0f4d.png">


- Checked if on including a logging statement in debug level in one of the tests, it prints the log statement in the pattern configured
<img width="1440" alt="Screenshot 2021-07-24 at 5 12 49 PM" src="https://user-images.githubusercontent.com/67866345/126871059-08914e0c-e729-47ef-b214-93a3bd62753e.png">

